### PR TITLE
score function now gives a minimum score of 1

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -311,9 +311,9 @@ end
 function score(data::DOMPData, k::Int64, d::Vector{Int64})::Int64
     nrows = size(data.D, 1)
     m = 1#abs(d[k] * data.lambda[k])
-    if k <= data.p return 0
-    elseif data.lambda[k] > 0 return m * (k - data.p + 1)
-    elseif data.lambda[k] < 0 return m * (nrows - k + 1)
-    else return 0
+    if k <= data.p return 1
+    elseif data.lambda[k] > 0 return m * (k - data.p + 1) + 1
+    elseif data.lambda[k] < 0 return m * (nrows - k + 1) + 1
+    else return 1
     end
 end


### PR DESCRIPTION
This PR resolves an issue occuring when a lambda index is given a score of 0. In that case, the contribution of this solution to the fractional solution is wrongly computed as 0 * x[k]. Now, every score is assigned a value of >= 1